### PR TITLE
Place the cached files for the rust_changelog source in their own folder

### DIFF
--- a/src/source/channel_manifests/dl.rs
+++ b/src/source/channel_manifests/dl.rs
@@ -11,6 +11,8 @@ const META_MANIFEST: &str = "https://static.rust-lang.org/manifests.txt";
 const META_MANIFEST_STALENESS_TIMEOUT: Duration = Duration::from_secs(86_400);
 // 1 year timeout for the individual release manifests (these manifests should not get outdated)
 const RELEASE_MANIFEST_STALENESS_TIMEOUT: Duration = Duration::from_secs(31_557_600);
+// Directory where cached files reside for this source
+const SOURCE_CACHE_DIR: &str = "source_channel_manifests";
 
 /// Download the meta manifest, unless it exists in the cache and is not stale
 pub(in crate::source::channel_manifests) fn fetch_meta_manifest() -> TResult<Document> {
@@ -54,7 +56,7 @@ pub(in crate::source::channel_manifests) fn fetch_release_manifests(
 
 fn from_manifests_cache_dir() -> TResult<PathBuf> {
     let cache = base_cache_dir()?;
-    Ok(cache.join("index"))
+    Ok(cache.join(SOURCE_CACHE_DIR))
 }
 
 fn manifest_file_name(source: &ManifestSource) -> String {

--- a/src/source/rust_changelog/dl.rs
+++ b/src/source/rust_changelog/dl.rs
@@ -5,9 +5,10 @@ use std::time::Duration;
 
 const URL: &str = "https://raw.githubusercontent.com/rust-lang/rust/master/RELEASES.md";
 const TIMEOUT: Duration = Duration::from_secs(86_400);
+const SOURCE_CACHE_DIR: &str = "source_rust_changelog";
 
 pub(in crate::source::rust_changelog) fn fetch_releases_md() -> TResult<Document> {
-    let cache = base_cache_dir()?;
+    let cache = base_cache_dir()?.join(SOURCE_CACHE_DIR);
     let source = download_if_not_stale(URL, &cache, "RELEASES.md", TIMEOUT)?;
 
     Ok(source)

--- a/src/source/rust_dist/dl.rs
+++ b/src/source/rust_dist/dl.rs
@@ -25,8 +25,11 @@ const OUTPUT_PATH: &str = "dist_static-rust-lang-org.txt";
 // Use the filtered index cache for up to 1 day
 const TIMEOUT: Duration = Duration::from_secs(86_400);
 
+// Directory where cached files reside for this source
+const SOURCE_CACHE_DIR: &str = "source_dist_index";
+
 pub(in crate::source::rust_dist) fn fetch() -> TResult<Document> {
-    let cache_dir = base_cache_dir()?.join("source_dist_index");
+    let cache_dir = base_cache_dir()?.join(SOURCE_CACHE_DIR);
     let output_path = cache_dir.join(OUTPUT_PATH);
 
     // Use the locally cached version if it exists, and is not stale


### PR DESCRIPTION
closes #17 