### PR TITLE
Add search_with_result to Bisect

### DIFF
--- a/src/index/bisect.rs
+++ b/src/index/bisect.rs
@@ -15,6 +15,91 @@ impl<'slice> Bisect<'slice> {
     /// The binary search is instrumented by a narrowing function `f`, which is used to determine
     /// to which side the slice should be narrowed.
     ///
+    /// In `search_with_result`, the narrowing function returns a `Result<Narrow, E>` instead of
+    /// simply a `Narrow`. This can be useful if your narrowing function can fail externally.
+    /// For example, in [`cargo-msrv`], when bisecting Rust version for the Minumum Supported Rust Version,
+    /// we run the Cargo and the Rust compiler as an external process. The external process can fail in multiple
+    /// ways which are unrelated to whether the Cargo project is compatible with a certain Rust version (e.g.
+    /// `cargo` is not on the PATH). In such cases, we want to notify the user of these external errors,
+    /// and return an error `E`.
+    ///
+    /// # Error type
+    ///
+    /// The narrowing function `f`, requires a `Fn` closure which returns an error with type `E`,
+    /// which is bound to the method. In some cases, the Rust compiler may not be able to figure out
+    /// what the type of `E` must be. This can be resolved by manually annotating the result type.
+    /// For example, you can return an explicit `Result::Ok::<Narrow, MyErrorType>(Narrow::ToLeft)`
+    /// from within the closure where you would otherwise return a regular `Ok(NarrowToLeft)`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rust_releases::Release;
+    /// use rust_releases::index::{Bisect, Narrow};
+    ///
+    /// #[derive(Debug)]
+    /// struct RequiresRust2018;
+    ///
+    /// let items = vec![
+    ///     Release::new(semver::Version::new(1, 47, 0)),
+    ///     Release::new(semver::Version::new(1, 46, 0)),
+    ///     Release::new(semver::Version::new(1, 45, 2)),
+    ///     Release::new(semver::Version::new(1, 45, 1)),
+    ///     Release::new(semver::Version::new(1, 45, 0)),
+    ///     Release::new(semver::Version::new(1, 44, 0)),
+    ///     Release::new(semver::Version::new(1, 43, 0)),
+    ///     Release::new(semver::Version::new(1, 42, 0)),
+    ///     Release::new(semver::Version::new(1, 41, 0)),
+    /// ];
+    ///
+    /// let mut binary_search = Bisect::from_slice(items.as_slice());
+    ///
+    /// let output: Result<Option<usize>, RequiresRust2018> = binary_search.search_with_result(|release| {
+    ///     if release.version().minor < 31 {
+    ///         return Err(RequiresRust2018);
+    ///     }   
+    ///
+    ///     Ok(if release.version().minor >= 43 { Narrow::ToRight } else { Narrow::ToLeft })
+    /// });
+    ///
+    /// assert_eq!(items[output.unwrap().unwrap()].version().minor, 43)
+    ///
+    /// ```
+    ///
+    /// [`cargo-msrv`]: https://github.com/foresterre/cargo-msrv
+    pub fn search_with_result<E>(
+        &mut self,
+        f: impl Fn(&Release) -> Result<Narrow, E>,
+    ) -> Result<Option<usize>, E> {
+        let mut left = 0;
+        let mut right = self.view.len() - 1;
+        let mut result = None;
+
+        'search: while left <= right {
+            let mid_point: usize = ((left as f32 + right as f32) / 2f32).floor() as usize;
+
+            match f(&self.view[mid_point])? {
+                Narrow::ToLeft => {
+                    if mid_point >= 1 {
+                        right = mid_point - 1;
+                    } else {
+                        break 'search;
+                    }
+                }
+                Narrow::ToRight => {
+                    left = mid_point + 1;
+                    result = Some(mid_point);
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Perform a binary search on a slice of releases.
+    /// The binary search is instrumented by a narrowing function `f`, which is used to determine
+    /// to which side the slice should be narrowed.
+    ///
     /// # Example
     ///
     /// ```
@@ -41,29 +126,12 @@ impl<'slice> Bisect<'slice> {
     ///
     /// ```
     pub fn search(&mut self, f: impl Fn(&Release) -> Narrow) -> Option<usize> {
-        let mut left = 0;
-        let mut right = self.view.len() - 1;
-        let mut result = None;
+        // FIXME: replace with never type, see issue #35121 <https://github.com/rust-lang/rust/issues/35121>
+        #[derive(Debug)]
+        enum Never {}
 
-        'search: while left <= right {
-            let mid_point: usize = ((left as f32 + right as f32) / 2f32).floor() as usize;
-
-            match f(&self.view[mid_point]) {
-                Narrow::ToLeft => {
-                    if mid_point >= 1 {
-                        right = mid_point - 1;
-                    } else {
-                        break 'search;
-                    }
-                }
-                Narrow::ToRight => {
-                    left = mid_point + 1;
-                    result = Some(mid_point);
-                }
-            }
-        }
-
-        result
+        self.search_with_result(|release| Result::Ok::<Narrow, Never>(f(release)))
+            .unwrap()
     }
 }
 
@@ -78,8 +146,8 @@ impl<'slice> Bisect<'slice> {
 /// [`BinarySearch::search`]: crate::index::bisect::BinarySearch::search;
 #[derive(Clone, Copy, Debug)]
 pub enum Narrow {
-    ToRight,
     ToLeft,
+    ToRight,
 }
 
 #[cfg(test)]
@@ -184,5 +252,21 @@ mod tests {
         let output = searcher.search(|release| narrow_by_minor(release, 11)); // not in range;
 
         assert!(output.is_none());
+    }
+
+    #[test]
+    fn with_result_to_error() {
+        let items = vec![Release::new(semver::Version::new(1, 10, 0))];
+
+        let mut searcher = Bisect {
+            view: items.as_ref(),
+        };
+
+        #[derive(Debug)]
+        struct MyError;
+
+        let output = searcher.search_with_result(|_release| Err(MyError)); // not in range;
+
+        assert!(output.is_err());
     }
 }


### PR DESCRIPTION
Allows the narrowing function `f` to fail on an external error by having the closure return a Result.