### PR TITLE
Also export semver from rust-releases core lib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ pub mod linear;
 
 // core re-exports
 pub use rust_releases_core::{
-    Channel, CoreError, CoreResult, FetchResources, Release, ReleaseIndex, Source,
+    semver, Channel, CoreError, CoreResult, FetchResources, Release, ReleaseIndex, Source,
 };
 
 #[cfg(feature = "rust-releases-io")]


### PR DESCRIPTION
* In 0.14, the `semver` version used internally was re-exported
* 0.15 removed the export from `rust-releases`
* Is still accessible through `rust-releases-core` though

This patch adds the export to `rust-releases`, forwarded from `rust-releases-core`