### PR TITLE
Fix rust-releases as dependency example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,19 +61,20 @@
 //! as [`features`], add the following to your `Cargo.toml`:
 //!
 //! ```toml
-//! [dependencies]
-//! # replace `*` with latest version, and
-//! # replace `$RUST_RELEASES_SOURCE` with one of the implemented source
-//! rust-releases = { version = "*", default-features = false,
-//!     features = ["rust-release-$RUST_RELEASES_SOURCE"] }
+//! # replace `*` with latest version, and replace `$RUST_RELEASES_SOURCE` with one of the available source implementations
+//! [dependencies.rust-releases]
+//! version = "*"
+//! default-features = false
+//! features = ["rust-release-$RUST_RELEASES_SOURCE"]
 //! ```
 //!
 //! For example:
 //!
 //! ```toml
-//! [dependencies]
-//! rust-releases = { version = "0.15.0", default-features = false,
-//!     features = ["rust-release-rust-dist"] }
+//! [dependencies.rust-releases]
+//! version = "0.15.0"
+//! default-features = false
+//! features = ["rust-release-rust-dist"]
 //! ```
 //!
 //! # Implemented sources


### PR DESCRIPTION
Previously an inline TOML table was used, but it spanned multiple lines.
Presumably this was the case so no horizontal scrollbar would appear on the rust docs page.
Instead of using an inline table, now the regular table syntax is used.