### PR TITLE
Introduce distinct features for each of the source options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,16 @@ members = [
 
 [features]
 default = [
-    "rust-releases-channel-manifests",
-    "rust-releases-rust-changelog",
-    "rust-releases-rust-dist",
-    "rust-releases-rust-dist-with-cli"
+    "channel-manifests",
+    "rust-changelog",
+    "rust-dist",
+    "rust-dist-with-cli"
 ]
+
+channel-manifests = ["rust-releases-channel-manifests"]
+rust-changelog = ["rust-releases-rust-changelog"]
+rust-dist = ["rust-releases-rust-dist"]
+rust-dist-with-cli = ["rust-releases-rust-dist-with-cli"]
 
 io = ["rust-releases-io"]
 


### PR DESCRIPTION
* Functionally doesn't change the available source options, as specifying a source feature does exactly the same as specifying the source dependency crate (which is marked optional and thus available as a feature)
* However, by having it as a feature, it will show up in the docs as a knob users can turn, instead of having users either read the introduction docs carefully, or checking the root manifest file for optional dependencies which are not specified in the features section