### PR TITLE
Add basic docs for ChannelManifests source

### DIFF
--- a/crates/rust-releases-channel-manifests/src/errors.rs
+++ b/crates/rust-releases-channel-manifests/src/errors.rs
@@ -8,27 +8,35 @@ pub type ChannelManifestsResult<T> = Result<T, ChannelManifestsError>;
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ChannelManifestsError {
+    /// Returned when the channel is not available, that is, is unimplemented.
     #[error("Channel {0} is not available for the 'ChannelManifests' source type")]
     ChannelNotAvailable(Channel),
 
+    /// Returned when a retrieved manifest is not decodable as TOML.
     #[error("{0}")]
     DeserializeToml(#[from] toml::de::Error),
 
+    /// Returned when the manifest date can not be parsed.
     #[error("Unable to parse manifest date")]
     ParseManifestDate,
 
+    /// Returned when the manifest source can not be parsed from the top level meta manifest.
     #[error("Unable to parse a manifest source in the meta manifest")]
     ParseManifestSource,
 
+    /// Returned when the top level meta manifest can not be parsed.
     #[error("Unable to parse the meta manifest")]
     ParseMetaManifest,
 
+    /// Returned when there is an issue with a semver version.
     #[error("{0}")]
     ParseRustVersion(#[from] semver::Error),
 
+    /// Returned in case of an I/O error.
     #[error("{0}")]
     RustReleasesIoError(#[from] IoError),
 
+    /// Returned when the Rust version can not be found in a release manifest.
     #[error("Unable to find Rust version in release manifest")]
     RustVersionNotFoundInManifest,
 }

--- a/crates/rust-releases-channel-manifests/src/lib.rs
+++ b/crates/rust-releases-channel-manifests/src/lib.rs
@@ -1,3 +1,10 @@
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![deny(unsafe_code)]
+//! Please, see the [`rust-releases`] for additional documentation on how this crate can be used.
+//!
+//! [`rust-releases`]: https://docs.rs/rust-releases
+
 #[cfg(test)]
 #[macro_use]
 extern crate rust_releases_io;
@@ -17,6 +24,15 @@ pub(crate) mod release_manifest;
 
 pub use errors::{ChannelManifestsError, ChannelManifestsResult};
 
+/// A [`Source`] which parses Rust release data from channel manifests, which used to be published for
+/// each release. Since 2020-02-23, however, no more channel manifests have been published.
+///
+///
+/// See <a href="https://github.com/foresterre/rust-releases/issues/9">foresterre/rust-releases#9</a> which tracks the above issue.
+///
+/// This source should not be used anymore. Since the input data is outdated, this source has been deprecated.
+/// It will receive no further development and may be removed in the future.
+#[deprecated]
 pub struct ChannelManifests {
     documents: Vec<Document>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,10 +145,10 @@
 //!           <td rowspan="2"><code>rust-releases-channel-manifests</code></td>
 //!           <td>Source</td>
 //!           <td>✅</td>
-//!           <td rowspan="2">Stable, <strike>Beta & Nightly</strike><sup>To be implemented</sup></td>
+//!           <td rowspan="2">Stable, <strike>Beta & Nightly</strike><sup>Won't be implemented</sup></td>
 //!           <td>Medium</td>
 //!           <td>-</td>
-//!           <td rowspan="2">Input data has not been updated since 2020-02-23 <sup>(<a href="https://github.com/foresterre/rust-releases/issues/9">#9</a>)</sup>. Use <code>RustDist</code> instead.</td>
+//!           <td rowspan="2">Deprecated: Input data has not been updated since 2020-02-23 <sup>(<a href="https://github.com/foresterre/rust-releases/issues/9">#9</a>)</sup>. Use <code>RustDist</code> instead.</td>
 //!      </tr>
 //!      <tr>
 //!           <td>FetchResources</td>


### PR DESCRIPTION
These docs won't be further expanded as long as the Source is deprecated.