### PR TITLE
Add the two `time` rustsec advisories to the exception list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,5 +21,12 @@ ignore = [
     # Currently a replacement is not really available as it is a dependency of rusoto, which we use to
     # connect to AWS S3. AWS recently has been recruiting many Rust developers so maybe there will also be an official
     # AWS Rust SDK in the future?
-    "RUSTSEC-2020-0056"
+    "RUSTSEC-2020-0056",
+
+    # Potential segfault in the time crate
+    # NB: has been fixed in time >=0.2.23, however waiting on chrono crate to update
+    # chrono PR: https://github.com/chronotope/chrono/pull/578
+    "RUSTSEC-2020-0071",
+    # Potential segfault in localtime_r invocations, see 0071
+    "RUSTSEC-2020-0159",
 ]


### PR DESCRIPTION
* We're waiting for chrono to update
* We may want to update to time 0.3, and have this replace chrono
* Presumably very difficult to exploit the vulnerability, so not too high a risk