### PR TITLE
Replace rusoto with aws-sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [package.metadata]
-msrv = "1.51.0"
+msrv = "1.53.0"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 [![Crates.io license shield](https://img.shields.io/crates/l/rust-releases.svg)](https://crates.io/crates/rust-releases)
 [![MSRV shield](https://img.shields.io/badge/MSRV-1.51.0-informational)](https://github.com/foresterre/cargo-msrv)
 
+| rust-releases version | MSRV |
+|-----------------------|------|
+| 0.21.1                | 1.51 |
+| 0.22.0*               | 1.53 |
+
+`*` Unreleased, MSRV subject to change  
+
 ## Introduction
 
 The Rust programming language uses deterministic versioning for toolchain releases. Stable versions use SemVer, 

--- a/crates/rust-releases-rust-dist/Cargo.toml
+++ b/crates/rust-releases-rust-dist/Cargo.toml
@@ -13,11 +13,16 @@ repository = "https://github.com/foresterre/rust-releases"
 rust-releases-core = { version = "^0.21.0", path = "../rust-releases-core" }
 rust-releases-io = { version = "^0.21.0", path = "../rust-releases-io" }
 
-thiserror = "1.0.24"
+aws-config = "0.6.0"
+aws-sdk-s3 = "0.6.0"
+aws-sig-auth = "0.6.0" # required for unsigned requests workaround
+aws-smithy-client = "0.36.0" # required for unsigned requests workaround
+aws-smithy-http = "0.36.0" # required for unsigned requests workaround
 
 lazy_static = "1.4.0"
-rusoto_core = "0.47.0"
-rusoto_s3 = "0.47.0"
 regex = "1.4.5"
-# minimum is set because of RUSTSEC-2021-0124 advisory: https://rustsec.org/advisories/RUSTSEC-2021-0124
-tokio = "1.13.1"
+thiserror = "1.0.24"
+
+[dependencies.tokio]
+version = "1.13.1" # minimum is set because of RUSTSEC-2021-0124 advisory: https://rustsec.org/advisories/RUSTSEC-2021-0124
+features = ["full"] # full required by aws-sdk-s3

--- a/crates/rust-releases-rust-dist/src/errors.rs
+++ b/crates/rust-releases-rust-dist/src/errors.rs
@@ -1,3 +1,6 @@
+use aws_config::InvalidAppName;
+use aws_sdk_s3::error::ListObjectsV2Error;
+use aws_sdk_s3::SdkError;
 use rust_releases_core::Channel;
 
 /// A result type which binds the `RustDistError` to the error type.
@@ -12,6 +15,10 @@ pub type RustDistResult<T> = Result<T, RustDistError>;
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum RustDistError {
+    /// Returned in case of an error related to the AWS SDK
+    #[error("{0}")]
+    AwsError(#[from] AwsError),
+
     /// Returned in case a `Channel` is not available for the `Source`.
     #[error("Channel {0} is not yet available for the 'RustDist' source type")]
     ChannelNotAvailable(Channel),
@@ -29,17 +36,9 @@ pub enum RustDistError {
     #[error("{0}")]
     Io(#[from] std::io::Error),
 
-    /// Unable to fetch metadata about the available Rust releases.
-    #[error("Unable to fetch metadata about the available Rust releases: '{0}'")]
-    UnableToFetch(#[from] rusoto_core::RusotoError<rusoto_s3::ListObjectsV2Error>),
-
     /// Returned in case of an `rust-releases-io` i/o error.
     #[error("{0}")]
     RustReleasesIo(#[from] rust_releases_io::IoError),
-
-    /// Returned in case of a TLS error.
-    #[error("{0}")]
-    SecureConnectionError(#[from] rusoto_core::request::TlsError),
 
     /// Returned in case the input text cannot be parsed.
     #[error("{0}")]
@@ -50,4 +49,29 @@ pub enum RustDistError {
     /// The component is usually the `major`, `minor` or `patch` version.
     #[error("The '{0}' component of the version number could not be parsed. The input was: '{1}'")]
     UnableToParseVersionNumberComponent(&'static &'static str, String),
+}
+
+/// Errors returned by the AWS SDK.
+#[derive(Debug, thiserror::Error)]
+pub enum AwsError {
+    #[error("Unable to build an anonymous AWS S3 request: failed to disable signing")]
+    DisableSigning,
+
+    /// Returned when the app name is invalid. Since the app name is configured by the library,
+    /// it's a bug when this error is returned.
+    #[error("Could not configure AWS S3 client: {0}")]
+    InvalidAppName(#[from] InvalidAppName),
+
+    /// Failed to build the input required to make an anonymous AWS S3 request.
+    #[error("Unable to build the list objects operation")]
+    ListObjectsBuildOperationInput,
+
+    /// Returned when it's not possible to list the S3 objects in the Rust bucket, required to
+    /// build our releases index.
+    #[error("Unable to fetch Rust distribution index: {0}")]
+    ListObjectsError(Box<SdkError<ListObjectsV2Error>>),
+
+    /// Failed to build the operation required to make an anonymous AWS S3 request.
+    #[error("Unable to make list objects operation")]
+    ListObjectsMakeOperation,
 }

--- a/deny.toml
+++ b/deny.toml
@@ -5,10 +5,26 @@ confidence-threshold = 0.925
 allow = [
     "Apache-2.0",
     "BSD-3-Clause",
+    "ISC",
     "MIT",
     "MPL-2.0",
     "Unlicense",
     "Zlib",
+    "OpenSSL"
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c }
 ]
 
 [advisories]


### PR DESCRIPTION
Rusoto is unmaintained, and relies on outdated dependencies which RustSec reports as insecure.

The Rust AWS sdk is still in preview, but weighted against the above, already a better choice.

Unfortunately, no anonymous credential provider is available (like Rusoto or the Java AWS SDK).
We have to use a workaround instead, where we manually create the S3 operation using a lower level API, make the operation unsigned, and execute the operation using the lower level Smithy client.