### PR TITLE
Only ship with one default data source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       - name: test_all
         run: cargo test --verbose --all
 
+      - name: test_all_with_all_features
+        run: cargo test --verbose --all --all-features
+
   rustfmt:
     name: rustfmt
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,7 @@ members = [
 
 [features]
 default = [
-    "channel-manifests",
     "rust-changelog",
-    "rust-dist",
-    "rust-dist-with-cli"
 ]
 
 channel-manifests = ["rust-releases-channel-manifests"]

--- a/README.md
+++ b/README.md
@@ -130,13 +130,6 @@ They both get their input data from the Rust AWS S3 distribution bucket. When us
 with the `FetchResources` trait implementation. For `RustDistWithCLI`, you have to obtain the input data yourself (by running the
 `aws` cli with the following options `aws --no-sign-request s3 ls static-rust-lang-org/dist/ > dist.txt`<sup>(<a href="https://github.com/rust-lang/rust/issues/56971#issuecomment-527199391">source</a>)</sup>).
 
-You should **not** use the `ChannelManifests` source, unless you have a good reason to do so. This source had a lot of potential, as the input data is the most complete (although with a bit of extra work we can get the same data with `RustDist`). 
-With the published channel manifests, we could easily extend information about releases beyond the release version. The separate manifest files could be parsed rather fast, and
-new manifests can be downloaded iteratively.
-There were however also major downsides. The initial download is quite large, and slow (because of rate limiting), in the order of hours, and,
-the resource is approximately one-week out of date since the root manifest is only updated one week after a release <sup>(<a href="https://github.com/rust-lang/rust/issues/56971#issuecomment-527199391">source</a>)</sup>.
-Most importantly however, the input data has not been updated since 2020-02-23<sup>(<a href="https://github.com/foresterre/rust-releases/issues/9">#9</a>)</sup>. As a result, this source has been deprecated, and will not be further extended.
-
 ## Applications
 
 [cargo-msrv](https://github.com/foresterre/cargo-msrv) is a tool which can be used to determine the minimal supported Rust version (MSRV).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ build a catalog of released Rust versions. In addition, for all solution except 
           <td rowspan="2">Stable</td>
           <td>Fast</td>
           <td>-</td>
-          <td rowspan="2"></td>
+          <td rowspan="2"><i>Enabled by default. Disable by setting <code>default-features = false</code> for the <code>rust-releases</code> dependency in your Cargo.toml manifest.</i></td>
      </tr>
      <tr>
           <td>FetchResources</td>
@@ -82,7 +82,7 @@ build a catalog of released Rust versions. In addition, for all solution except 
           <td rowspan="2"><code>RustDistWithCLI</code></td>
           <td>Source</td>
           <td>✅</td>
-          <td rowspan="2">Stable, <strike>Beta & Nightly</strike><sup>To be implemented</sup></td>
+          <td rowspan="2">Stable, <strike>Beta & Nightly</strike><sup>TBD</sup></td>
           <td>Fast</td>
           <td>-</td>
           <td rowspan="2"></td>
@@ -94,13 +94,13 @@ build a catalog of released Rust versions. In addition, for all solution except 
           <td>~8 MB</td>
      </tr>
      <tr>
-          <td rowspan="2"><code><strike>ChannelManifests</strike></code><sup>Deprecated</sup></td>
+          <td rowspan="2"><code><strike>ChannelManifests</strike></code><sup>TDB</sup></td>
           <td>Source</td>
           <td>✅</td>
-          <td rowspan="2">Stable, <strike>Beta & Nightly</strike><sup>Won't be implemented</sup></td>
+          <td rowspan="2">Stable, <strike>Beta & Nightly</strike><sup>TBD</sup></td>
           <td>Medium</td>
           <td>-</td>
-          <td rowspan="2">Input data not updated since 2020-02-23<sup>(<a href="https://github.com/foresterre/rust-releases/issues/9">#9</a>)</sup></td>
+          <td rowspan="2">Input data works again<sup>(<a href="https://github.com/foresterre/rust-releases/issues/9">#9</a>)</sup>. Further implementation commitments TBD<sup>5</sup></td>
      </tr>
      <tr>
           <td>FetchResources</td>
@@ -114,7 +114,11 @@ build a catalog of released Rust versions. In addition, for all solution except 
 <sup>1</sup>: Currently most of the `rust-releases` public API supports only stable. Support for the beta and nightly channel is work-in-progress, and the table currently lists whether there is theoretical support for these channels.<br> 
 <sup>2</sup>: Speed for the `Source` trait primarily consist of parsing speed<br> 
 <sup>3</sup>: Speed for the `FetchResources` trait is primarily limited by your own download speed, and the rate limiting of the server from which the resources are fetched<br>
-<sup>4</sup>: Approximate as of 2021-03-03 <br>
+<sup>4</sup>: Approximate as of 2021-03-03<br>
+<sup>5</sup>: While the channel manifests are the most complete source available, they're practically too slow to download without
+adding some incremental implementation first, while this would still require a large initial download. Since
+we currently do not use most of the data available in the manifest files, it's usually better to instead pick
+a different source. It's more likely we'll take the channel manifests, take a subset and compile it into a smaller source type.<br>
 
 **Which data source should I use?**
 


### PR DESCRIPTION
Reduces compile time, especially when you wouldn't use all sources anyway.