### PR TITLE
Replace chrono crate with time crate

### DIFF
--- a/crates/rust-releases-rust-changelog/Cargo.toml
+++ b/crates/rust-releases-rust-changelog/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/foresterre/rust-releases"
 msrv = "1.46.0"
 
 [dependencies]
-chrono = "0.4.19"
+time = { version = "0.3.7", features = ["macros", "parsing"] }
 rust-releases-core = { version = "^0.22.0", path = "../rust-releases-core" }
 rust-releases-io = { version = "^0.22.0", path = "../rust-releases-io", features = ["http_client"] }
 thiserror = "1.0.24"

--- a/crates/rust-releases-rust-changelog/Cargo.toml
+++ b/crates/rust-releases-rust-changelog/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/rust-releases-rust-changelog"
 repository = "https://github.com/foresterre/rust-releases"
 
 [package.metadata]
-msrv = "1.46.0"
+msrv = "1.53.0"
 
 [dependencies]
 time = { version = "0.3.7", features = ["macros", "parsing"] }

--- a/crates/rust-releases-rust-changelog/src/errors.rs
+++ b/crates/rust-releases-rust-changelog/src/errors.rs
@@ -14,7 +14,7 @@ pub enum RustChangelogError {
 
     /// Returned in case of of `chrono` parse errors
     #[error("Unable to parse release date in a release entry '{0}'")]
-    ChronoParseError(String),
+    TimeParseError(String),
 
     /// Returned in a case a release entry does not contain a recognizable release date
     #[error("Unable to find a valid release date in a release entry")]

--- a/crates/rust-releases-rust-changelog/src/errors.rs
+++ b/crates/rust-releases-rust-changelog/src/errors.rs
@@ -13,8 +13,8 @@ pub enum RustChangelogError {
     ChannelNotAvailable(Channel),
 
     /// Returned in case of of `chrono` parse errors
-    #[error("Unable to parse release date in a release entry '{0}'")]
-    TimeParseError(String),
+    #[error("Unable to parse release date in a release entry '{0}': {1}")]
+    TimeParseError(String, time::error::Parse),
 
     /// Returned in a case a release entry does not contain a recognizable release date
     #[error("Unable to find a valid release date in a release entry")]

--- a/crates/rust-releases-rust-changelog/src/lib.rs
+++ b/crates/rust-releases-rust-changelog/src/lib.rs
@@ -132,11 +132,13 @@ fn parse_release<'line>(
 }
 
 #[derive(Debug)]
-struct ReleaseDate(time::OffsetDateTime);
+struct ReleaseDate(time::Date);
 
 impl ReleaseDate {
     fn today() -> Self {
-        Self(time::OffsetDateTime::now_utc())
+        let date = time::OffsetDateTime::now_utc().date();
+
+        Self(date)
     }
 
     fn parse(from: &str) -> Result<Self, RustChangelogError> {
@@ -154,8 +156,8 @@ impl FromStr for ReleaseDate {
     fn from_str(item: &str) -> Result<Self, Self::Err> {
         let format = format_description!("[year]-[month]-[day]");
 
-        let result = time::OffsetDateTime::parse(item, &format)
-            .map_err(|_| RustChangelogError::TimeParseError(item.to_string()))?;
+        let result = time::Date::parse(item.trim(), &format)
+            .map_err(|err| RustChangelogError::TimeParseError(item.to_string(), err))?;
 
         Ok(Self(result))
     }
@@ -191,7 +193,7 @@ mod tests {
     fn parse_date() {
         let date = ReleaseDate::parse("2021-09-01").unwrap();
         let expected = date!(2021 - 09 - 01);
-        assert_eq!(date.0.date(), expected);
+        assert_eq!(date.0, expected);
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -32,11 +32,4 @@ vulnerability = "deny"
 unmaintained = "deny"
 notice = "deny"
 
-ignore = [
-    # Potential segfault in the time crate
-    # NB: has been fixed in time >=0.2.23, however waiting on chrono crate to update
-    # chrono PR: https://github.com/chronotope/chrono/pull/578
-    "RUSTSEC-2020-0071",
-    # Potential segfault in localtime_r invocations, see 0071
-    "RUSTSEC-2020-0159",
-]
+ignore = []


### PR DESCRIPTION
Chrono is known to be unmaintained, and has some open RustSec issues. Since it seems like these issues will not be fixed soon, and time is more than good enough now, switching to time seems to be the right call.