### PR TITLE
Update aws sdk libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "/bors.toml", # CI staging bot config
     "/deny.toml" # dependency license checking config
 ]
-rust-version = "1.63"
+rust-version = "1.65"
 
 [package.metadata.release]
 tag-name = "v{{version}}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "/bors.toml", # CI staging bot config
     "/deny.toml" # dependency license checking config
 ]
-rust-version = "1.65"
+rust-version = "1.67"
 
 [package.metadata.release]
 tag-name = "v{{version}}"

--- a/crates/rust-releases-rust-changelog/Cargo.toml
+++ b/crates/rust-releases-rust-changelog/Cargo.toml
@@ -7,7 +7,7 @@ description = "RustChangelog source implementation for rust-releasess"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/rust-releases-rust-changelog"
 repository = "https://github.com/foresterre/rust-releases"
-rust-version = "1.65"
+rust-version = "1.67"
 
 [dependencies]
 time = { version = "0.3.7", features = ["macros", "parsing"] }

--- a/crates/rust-releases-rust-changelog/Cargo.toml
+++ b/crates/rust-releases-rust-changelog/Cargo.toml
@@ -7,7 +7,7 @@ description = "RustChangelog source implementation for rust-releasess"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/rust-releases-rust-changelog"
 repository = "https://github.com/foresterre/rust-releases"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [dependencies]
 time = { version = "0.3.7", features = ["macros", "parsing"] }

--- a/crates/rust-releases-rust-dist/Cargo.toml
+++ b/crates/rust-releases-rust-dist/Cargo.toml
@@ -7,7 +7,7 @@ description = "RustDist source implementation for rust-releases"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/rust-releases-rust-dist"
 repository = "https://github.com/foresterre/rust-releases"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [dependencies]
 rust-releases-core = { version = "^0.26.0", path = "../rust-releases-core" }

--- a/crates/rust-releases-rust-dist/Cargo.toml
+++ b/crates/rust-releases-rust-dist/Cargo.toml
@@ -13,9 +13,8 @@ rust-version = "1.63"
 rust-releases-core = { version = "^0.26.0", path = "../rust-releases-core" }
 rust-releases-io = { version = "^0.26.0", path = "../rust-releases-io" }
 
-aws-config = "0.55.1"
-aws-sdk-s3 = "0.27.0"
-aws-sig-auth = "0.55.1" # required for unsigned requests workaround
+aws-config = "0.56.1"
+aws-sdk-s3 = "0.30.0"
 
 lazy_static = "1.4.0"
 regex = "1.8.1"

--- a/crates/rust-releases-rust-dist/Cargo.toml
+++ b/crates/rust-releases-rust-dist/Cargo.toml
@@ -7,7 +7,7 @@ description = "RustDist source implementation for rust-releases"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/rust-releases-rust-dist"
 repository = "https://github.com/foresterre/rust-releases"
-rust-version = "1.65"
+rust-version = "1.67"
 
 [dependencies]
 rust-releases-core = { version = "^0.26.0", path = "../rust-releases-core" }

--- a/crates/rust-releases-rust-dist/src/errors.rs
+++ b/crates/rust-releases-rust-dist/src/errors.rs
@@ -1,5 +1,4 @@
 use aws_config::InvalidAppName;
-use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error;
 use rust_releases_core::Channel;
 
@@ -66,14 +65,10 @@ pub enum AwsError {
     #[error("Could not configure AWS S3 client: {0}")]
     InvalidAppName(#[from] InvalidAppName),
 
-    /// Failed to build the input required to make an anonymous AWS S3 request.
-    #[error("Unable to build the list objects operation")]
-    ListObjectsBuildOperationInput,
-
     /// Returned when it's not possible to list the S3 objects in the Rust bucket, required to
     /// build our releases index.
     #[error("Unable to fetch Rust distribution index: {0}")]
-    ListObjectsError(Box<SdkError<ListObjectsV2Error>>),
+    ListObjectsError(Box<ListObjectsV2Error>),
 
     /// Failed to build the operation required to make an anonymous AWS S3 request.
     #[error("Unable to make list objects operation")]

--- a/crates/rust-releases-rust-dist/src/fetch.rs
+++ b/crates/rust-releases-rust-dist/src/fetch.rs
@@ -106,6 +106,10 @@ impl ChunkClient for Client {
             .runtime
             .block_on(list_objects(&self.aws_s3_client, offset))?;
 
+        if !raw.is_truncated() {
+            return Ok(ChunkState::Complete);
+        }
+
         let objects = raw.contents.ok_or(RustDistError::ChunkMetadataMissing)?;
         let state = match write_objects(to, &objects) {
             Some(key) => ChunkState::Offset(key),

--- a/deny.toml
+++ b/deny.toml
@@ -28,6 +28,13 @@ license-files = [
     { path = "LICENSE", hash = 0x001c7e6c }
 ]
 
+[[licenses.clarify]]
+name = "rustls-webpki"
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c }
+]
+
 [advisories]
 vulnerability = "deny"
 unmaintained = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -33,4 +33,4 @@ vulnerability = "deny"
 unmaintained = "deny"
 notice = "deny"
 
-ignore = []
+ignore = [" RUSTSEC-2023-0052"]


### PR DESCRIPTION
aws-config: 0.56.1
aws-sdk-s3: 0.30.0
aws-sig-auth: removed, now tries to use aws_config::from_env().no_credentials() instead

