### PR TITLE
Group dependency updates for aws packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,11 @@ updates:
   open-pull-requests-limit: 10
   labels:
     - C-dependency-update
+  groups:
+    aws:
+      patterns:
+      - "aws-*"
+      update-types:
+      - "major"
+      - "minor"
+      - "patch"


### PR DESCRIPTION
* The aws packages are largely interdependent
* As a result, they often need manual upgrades, because dependabot thus far always only updated one at a time