### PR TITLE
feat: support network proxy from environment

### DIFF
--- a/crates/rust-releases-io/src/client/cached_client.rs
+++ b/crates/rust-releases-io/src/client/cached_client.rs
@@ -170,15 +170,13 @@ fn setup_cache_folder(manifest_path: &Path) -> Result<(), CachedClientError> {
 }
 
 fn fetch_file(url: &str) -> Result<Box<dyn Read + Send + Sync>, CachedClientError> {
-    let response = ureq::get(url)
-        .set(
-            "User-Agent",
-            "rust-releases (github.com/foresterre/rust-releases/issues)",
-        )
-        .call()
-        .map_err(|err| HttpError {
-            error: Box::new(err),
-        })?;
+    let agent = ureq::AgentBuilder::new()
+        .user_agent("rust-releases (github.com/foresterre/rust-releases/issues)")
+        .try_proxy_from_env(true)
+        .build();
+    let response = agent.get(url).call().map_err(|err| HttpError {
+        error: Box::new(err),
+    })?;
 
     Ok(response.into_reader())
 }


### PR DESCRIPTION
In current implementation, `rust-releases-io` will just ignore HTTP_PROXY/HTTPS_PROXY
When users cannot access github without a proxy, this results an error like: 
```text
HTTP error: https://raw.githubusercontent.com/rust-lang/rust/master/RELEASES.md: Connection Failed: Connect error: Connection refused (os error 111)
```

With `ureq:Agent`, `rust-releases-io` will try to read proxy from environment
This avoids requirement of hook-based/cgroup-based/tun-based e.g. proxy tools