### PR TITLE
Add target tier to Target struct

### DIFF
--- a/crates/rust-toolchain/src/channel.rs
+++ b/crates/rust-toolchain/src/channel.rs
@@ -2,7 +2,7 @@ mod beta;
 mod nightly;
 mod stable;
 
-use crate::{RustVersion, ToolchainDate};
+use crate::{RustVersion, ShortDate};
 
 pub use beta::Beta;
 pub use nightly::Nightly;
@@ -42,7 +42,7 @@ impl Channel {
     }
 
     /// Create a new [`Nightly`] channel instance.
-    pub fn nightly(date: ToolchainDate) -> Self {
+    pub fn nightly(date: ShortDate) -> Self {
         Channel::Nightly(Nightly { date })
     }
 
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn create_channel_nightly() {
-        let stable = Channel::nightly(ToolchainDate::new(1, 1, 1));
+        let stable = Channel::nightly(ShortDate::new(1, 1, 1));
 
         assert!(!stable.is_stable());
         assert!(!stable.is_beta());

--- a/crates/rust-toolchain/src/channel/nightly.rs
+++ b/crates/rust-toolchain/src/channel/nightly.rs
@@ -1,13 +1,13 @@
-use crate::ToolchainDate;
+use crate::ShortDate;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct Nightly {
-    pub date: ToolchainDate,
+    pub date: ShortDate,
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{Nightly, ToolchainDate};
+    use crate::{Nightly, ShortDate};
 
     #[yare::parameterized(
         patch1 = { ToolchainDate::new(0, 0, 0), ToolchainDate::new(0, 0, 1) },
@@ -17,7 +17,7 @@ mod tests {
         major_trumps_patch = { ToolchainDate::new(0, 0, 99), ToolchainDate::new(1, 0, 0) },
         major_trumps_minor = { ToolchainDate::new(0, 99, 0), ToolchainDate::new(1, 0, 0) },
     )]
-    fn ord(left: ToolchainDate, right: ToolchainDate) {
+    fn ord(left: ShortDate, right: ShortDate) {
         let left = Nightly { date: left };
         let right = Nightly { date: right };
 

--- a/crates/rust-toolchain/src/date.rs
+++ b/crates/rust-toolchain/src/date.rs
@@ -2,11 +2,11 @@ use std::fmt;
 
 /// A release date for a Rust release.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
-pub struct ToolchainDate {
+pub struct ShortDate {
     date: DateImpl,
 }
 
-impl ToolchainDate {
+impl ShortDate {
     /// Create a new `ToolchainDate` instance.
     ///
     /// While it is called a `date`, it is merely a shallow representation of
@@ -26,7 +26,7 @@ impl ToolchainDate {
 
     /// Prints a yyyy-mm-dd representation of a release date.
     ///
-    /// This representation may, just like [`ToolchainDate`], be not a valid date
+    /// This representation may, just like [`ShortDate`], be not a valid date
     /// in the Gregorian calendar. The date is merely a representation.
     ///
     /// Year, month, and day will all be pre-filled with 0's.
@@ -65,8 +65,8 @@ mod tests {
         one_two_three = { ToolchainDate::new(1, 2, 3), 1, 2, 3 },
         max = { ToolchainDate::new(u16::MAX, u8::MAX, u8::MAX), u16::MAX, u8::MAX, u8::MAX },
     )]
-    fn create_release_date(date: ToolchainDate, year: u16, month: u8, day: u8) {
-        let expected = ToolchainDate {
+    fn create_release_date(date: ShortDate, year: u16, month: u8, day: u8) {
+        let expected = ShortDate {
             date: DateImpl { year, month, day },
         };
 
@@ -75,8 +75,8 @@ mod tests {
 
     #[test]
     fn compare_year() {
-        let smaller = ToolchainDate::new(2000, 1, 1);
-        let bigger = ToolchainDate::new(2001, 1, 1);
+        let smaller = ShortDate::new(2000, 1, 1);
+        let bigger = ShortDate::new(2001, 1, 1);
 
         assert!(smaller < bigger);
         assert!(smaller <= bigger);
@@ -84,8 +84,8 @@ mod tests {
 
     #[test]
     fn compare_month() {
-        let smaller = ToolchainDate::new(2000, 1, 1);
-        let bigger = ToolchainDate::new(2000, 2, 1);
+        let smaller = ShortDate::new(2000, 1, 1);
+        let bigger = ShortDate::new(2000, 2, 1);
 
         assert!(smaller < bigger);
         assert!(smaller <= bigger);
@@ -93,8 +93,8 @@ mod tests {
 
     #[test]
     fn compare_day() {
-        let smaller = ToolchainDate::new(2000, 1, 1);
-        let bigger = ToolchainDate::new(2000, 1, 2);
+        let smaller = ShortDate::new(2000, 1, 1);
+        let bigger = ShortDate::new(2000, 1, 2);
 
         assert!(smaller < bigger);
         assert!(smaller <= bigger);
@@ -108,14 +108,14 @@ mod tests {
         invalid_month_is_not_rejected = { ToolchainDate::new(1000, 100, 1), "1000-100-01"  },
         invalid_day_is_not_rejected = { ToolchainDate::new(1000, 1, 100), "1000-01-100"  },
     )]
-    fn to_string(date: ToolchainDate, expected: &str) {
+    fn to_string(date: ShortDate, expected: &str) {
         assert_eq!(date.ymd().to_string(), expected.to_string());
     }
 
     #[test]
     fn newer_date() {
-        let newer = ToolchainDate::new(2000, 1, 1);
-        let older = ToolchainDate::new(1999, 1, 1);
+        let newer = ShortDate::new(2000, 1, 1);
+        let older = ShortDate::new(1999, 1, 1);
 
         assert_eq!(newer.cmp(&older), Ordering::Greater);
     }

--- a/crates/rust-toolchain/src/lib.rs
+++ b/crates/rust-toolchain/src/lib.rs
@@ -29,7 +29,7 @@ mod toolchain;
 
 pub use channel::{Beta, Channel, Nightly, Stable};
 pub use component::Component;
-pub use date::ToolchainDate;
+pub use date::ShortDate;
 pub use rust_version::RustVersion;
-pub use target::Target;
+pub use target::{Target, Tier};
 pub use toolchain::Toolchain;

--- a/crates/rust-toolchain/src/target.rs
+++ b/crates/rust-toolchain/src/target.rs
@@ -13,6 +13,7 @@ use std::str::FromStr;
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Target {
     target: target_lexicon::Triple,
+    tier: Option<Tier>,
 }
 
 impl Target {
@@ -21,6 +22,7 @@ impl Target {
     pub const fn host() -> Self {
         Self {
             target: target_lexicon::HOST,
+            tier: None,
         }
     }
 
@@ -32,7 +34,10 @@ impl Target {
     pub fn try_from_target_triple(triple: &str) -> Result<Self, ParseError> {
         let platform = target_lexicon::Triple::from_str(triple).map_err(ParseError::from)?;
 
-        Ok(Self { target: platform })
+        Ok(Self {
+            target: platform,
+            tier: None,
+        })
     }
 
     /// Create a new `Target` instance from a [`target triple`], defaults to
@@ -45,7 +50,10 @@ impl Target {
         let platform = target_lexicon::Triple::from_str(triple)
             .unwrap_or_else(|_| target_lexicon::Triple::unknown());
 
-        Self { target: platform }
+        Self {
+            target: platform,
+            tier: None,
+        }
     }
 }
 
@@ -81,6 +89,15 @@ impl From<target_lexicon::ParseError> for ParseError {
     }
 }
 
+/// Support tier for the target
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Tier {
+    T1,
+    T2,
+    T2_5,
+    T3,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,6 +108,7 @@ mod tests {
 
         let expected = Target {
             target: target_lexicon::HOST,
+            tier: None,
         };
 
         assert_eq!(this_platform, expected);

--- a/crates/rust-toolchain/src/toolchain.rs
+++ b/crates/rust-toolchain/src/toolchain.rs
@@ -1,11 +1,11 @@
-use crate::{Channel, Component, Target, ToolchainDate};
+use crate::{Channel, Component, ShortDate, Target};
 use std::collections::HashSet;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Toolchain {
     channel: Channel,
-    date: Option<ToolchainDate>,
+    date: Option<ShortDate>,
     host: Target,
 
     components: HashSet<Component>,
@@ -15,7 +15,7 @@ pub struct Toolchain {
 impl Toolchain {
     pub fn new(
         channel: Channel,
-        date: Option<ToolchainDate>,
+        date: Option<ShortDate>,
         host: Target,
         components: HashSet<Component>,
         targets: HashSet<Target>,
@@ -33,7 +33,7 @@ impl Toolchain {
         &self.channel
     }
 
-    pub fn date(&self) -> &Option<ToolchainDate> {
+    pub fn date(&self) -> &Option<ShortDate> {
         &self.date
     }
 


### PR DESCRIPTION
Tier is optional for each target, as it may not be known in advance. Tiers may even change over time, so perhaps we should only add them to RustReleases as metadata instead.